### PR TITLE
Fix Swiper layout in Firefox

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,7 +33,6 @@ const typed = new Typed(".multiple-text", {
 // PORTFOLIO SWIPER
 
 let swiper = new Swiper(".portfolio-content", {
-   cssMode: true,
    loop: true,
    navigation: {
       nextEl: ".swiper-button-next",

--- a/style.css
+++ b/style.css
@@ -307,11 +307,8 @@ The thumb is the slider knob that you drag along the path. */
 }
 
 .portfolio-content {
-   display: grid;
-   grid-template-columns: repeat(auto-fit, minmax(350px, auto));
-   justify-content: center;
-   align-items: center;
-   gap: 2.3rem;
+   display: flex;
+   overflow: hidden;
    border-radius: 28px;
    border: 0.1px solid var(--main-color);
    box-shadow: 0px 0px 3px var(--main-color);


### PR DESCRIPTION
## Summary
- remove grid layout that conflicted with Swiper
- drop `cssMode` to rely on default Swiper behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68475c0ceaec8329831d4f9181d12137